### PR TITLE
Ensure customer email reloaded on verify

### DIFF
--- a/src/AppBundle/Notifications/NotificationFactory/CustomerEmail/VerifyGenerate.php
+++ b/src/AppBundle/Notifications/NotificationFactory/CustomerEmail/VerifyGenerate.php
@@ -22,6 +22,7 @@ class VerifyGenerate implements NotificationFactoryInterface
     public function generate(Model $submission, Model $template = null, array $args)
     {
         $email = $this->getCustomerEmail($submission, $submission->get('payload')->customer['primaryEmail']);
+        $email->reload();
         $args['verificationLink'] = $this->getVerificationLink($submission, $email, $args['application']);
         $args['verificationEmail'] = $email->get('value');
         $args['subject'] = $this->appendFallbackSubject($args, 'Verify your email for %s');


### PR DESCRIPTION
Due to some oddities with the modlr identity map and inverse relationships, the email model was maintaining the old token when generating a new verify email. This caused the link to be incorrect within the notification. Reloading the email ensures the correct value is present. Resolves #19 
