### PR TITLE
Add legacy password encoding/updating support

### DIFF
--- a/app/config/services/security.yml
+++ b/app/config/services/security.yml
@@ -28,7 +28,7 @@ services:
     app_bundle.security.authenticator.customer:
         private: true
         class: AppBundle\Security\Authenticator\CustomerAuthenticator
-        arguments: [ "@as3_modlr.api.adapter", "@security.http_utils", "@security.encoder_factory", "@app_bundle.security.auth.generator_manager" ]
+        arguments: [ "@as3_modlr.api.adapter", "@security.http_utils", "@security.encoder_factory", "@app_bundle.security.auth.generator_manager", "@app_bundle.security.encoder.legacy_encoder_manager" ]
         calls:
             - [ addRoute, [ "app_bundle_app_auth_submit" ] ]
 
@@ -42,6 +42,16 @@ services:
     app_bundle.security.authenticator.core_user.abstract:
         private: true
         abstract: true
+
+    app_bundle.security.encoder.legacy_encoder_manager:
+        private: true
+        class: AppBundle\Security\Encoder\LegacyEncoderManager
+        calls:
+            - [ addEncoder, [ "@app_bundle.security.encoder.legacy.merrick" ] ]
+
+    app_bundle.security.encoder.legacy.merrick:
+        private: true
+        class: AppBundle\Security\Encoder\MerrickPasswordEncoder
 
     app_bundle.security.jwt.generator_manager:
         private: true

--- a/src/AppBundle/Security/Encoder/LegacyEncoderInterface.php
+++ b/src/AppBundle/Security/Encoder/LegacyEncoderInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace AppBundle\Security\Encoder;
+
+use Symfony\Component\Security\Core\Encoder\PasswordEncoderInterface;
+
+/**
+ * The legacy encoder implementation details
+ *
+ * @author Jacob Bare <jacob.bare@gmail.com>
+ */
+interface LegacyEncoderInterface extends PasswordEncoderInterface
+{
+    /**
+     * Gets the credential mechanism this password encoder supports.
+     *
+     * @return  string
+     */
+    public function getMechanism();
+}

--- a/src/AppBundle/Security/Encoder/LegacyEncoderManager.php
+++ b/src/AppBundle/Security/Encoder/LegacyEncoderManager.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace AppBundle\Security\Encoder;
+
+/**
+ * Manages legacy/alternative password encoders.
+ *
+ * @author Jacob Bare <jacob.bare@gmail.com>
+ */
+class LegacyEncoderManager
+{
+    const CORE_MECHANISM = 'platform';
+
+    private $encoders;
+
+    public function addEncoder(LegacyEncoderInterface $encoder)
+    {
+        $mechanism = $encoder->getMechanism();
+        if (self::CORE_MECHANISM === $mechanism) {
+            throw new \InvalidArgumentException('You cannot assign a legacy password encoder as the core mechanism.');
+        }
+        $this->encoders[$mechanism] = $encoder;
+        return $this;
+    }
+
+    public function getEncoder($mechanism)
+    {
+        if (isset($this->encoders[$mechanism])) {
+            return $this->encoders[$mechanism];
+        }
+    }
+}

--- a/src/AppBundle/Security/Encoder/MerrickPasswordEncoder.php
+++ b/src/AppBundle/Security/Encoder/MerrickPasswordEncoder.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace AppBundle\Security\Encoder;
+
+use Symfony\Component\Security\Core\Encoder\BasePasswordEncoder;
+use Symfony\Component\Security\Core\Exception\BadCredentialsException;
+
+/**
+ * Legacy password encoder for Merrick users.
+ *
+ * @author Jacob Bare <jacob.bare@gmail.com>
+ */
+class MerrickPasswordEncoder extends BasePasswordEncoder implements LegacyEncoderInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function encodePassword($raw, $salt)
+    {
+        if ($this->isPasswordTooLong($raw)) {
+            throw new BadCredentialsException('Invalid password.');
+        }
+        return sha1(md5($raw).$salt);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getMechanism()
+    {
+        return 'merrick';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isPasswordValid($encoded, $raw, $salt)
+    {
+        if ($this->isPasswordTooLong($raw)) {
+            return false;
+        }
+        return $encoded === $this->encodePassword($raw, $salt);
+    }
+}

--- a/src/AppBundle/Security/User/Customer.php
+++ b/src/AppBundle/Security/User/Customer.php
@@ -13,6 +13,7 @@ class Customer implements AdvancedUserInterface, Serializable
     private $familyName;
     private $givenName;
     private $locked = true;
+    private $mechanism;
     private $password;
     private $roles = [];
     private $salt;
@@ -33,9 +34,10 @@ class Customer implements AdvancedUserInterface, Serializable
         if (null !== $credentials && null !== $password = $credentials->get('password')) {
             $this->password   = $password->get('value');
             $this->salt       = $password->get('salt');
+            $this->mechanism  = $password->get('mechanism');
             $this->username   = $customer->getId();
-        }
 
+        }
         if (null !== $settings = $customer->get('settings')) {
             $this->locked  = $settings->get('locked');
             $this->enabled = $settings->get('enabled');
@@ -51,6 +53,11 @@ class Customer implements AdvancedUserInterface, Serializable
     public function getGivenName()
     {
         return $this->givenName;
+    }
+
+    public function getMechanism()
+    {
+        return $this->mechanism;
     }
 
     public function getModel()
@@ -141,6 +148,7 @@ class Customer implements AdvancedUserInterface, Serializable
             $this->username,
             $this->locked,
             $this->enabled,
+            $this->mechanism
         ]);
     }
 
@@ -154,7 +162,8 @@ class Customer implements AdvancedUserInterface, Serializable
             $this->salt,
             $this->username,
             $this->locked,
-            $this->enabled
+            $this->enabled,
+            $this->mechanism
         ) = unserialize($serialized);
     }
 


### PR DESCRIPTION
Allows for registering alternate password encoding mechanisms. If an alternate/legacy mechanism is found on a customer, it will use the legacy encoder (if found) to authenticate. If authentication is successful, the customer's presented password will be re-encoded using the default encoder and the model will be updated in the database.

The encoding mechanism for Merrick was added (a sha1/md5 hash).
