### PR TITLE
Add ability to detect and subscribe to identity id

### DIFF
--- a/src/AppBundle/Customer/CustomerManager.php
+++ b/src/AppBundle/Customer/CustomerManager.php
@@ -83,6 +83,9 @@ class CustomerManager
         $user = $this->getSecurityUser();
         if ($user) {
             $serialized = $this->authGenerator->generateFor($user);
+            // @todo Remove sending the identity once backend tracking (Sapience/Olytics) has been integrated.
+            $customer = $this->getActiveCustomer();
+            $serialized['identity'] = (null === $customer) ? null : $customer->getId();
             return new JsonResponse($serialized);
         }
         return $this->createDefaultAuthResponse();
@@ -97,6 +100,9 @@ class CustomerManager
     {
         $model = $this->getStore()->create('customer-account');
         $serialized = $this->authGenerator->getSerializer()->serialize($model);
+        // @todo Remove sending the identity once backend tracking (Sapience/Olytics) has been integrated.
+        $customer = $this->getActiveCustomer();
+        $serialized['identity'] = (null === $customer) ? null : $customer->getId();
         return new JsonResponse($serialized);
     }
 

--- a/src/AppBundle/Resources/library/js/customer-manager.js
+++ b/src/AppBundle/Resources/library/js/customer-manager.js
@@ -1,6 +1,8 @@
 function CustomerManager()
 {
     var customer = getDefaultCustomerObject();
+    // @todo Remove sending the identity once backend tracking (Sapience/Olytics) has been integrated.
+    var identity = null;
 
     EventDispatcher.subscribe('CustomerManager.login.success', function() {
         EventDispatcher.trigger('CustomerManager.customer.loaded');
@@ -13,6 +15,11 @@ function CustomerManager()
     this.init = function() {
         this.checkAuth().then(function (response) {
             customer = response.data;
+
+            // @todo Remove sending the identity once backend tracking (Sapience/Olytics) has been integrated.
+            identity = response.identity;
+            EventDispatcher.trigger('CustomerManager.identity.loaded');
+
             EventDispatcher.trigger('CustomerManager.customer.loaded');
             EventDispatcher.trigger('CustomerManager.init');
         }, function () {
@@ -24,6 +31,11 @@ function CustomerManager()
         var promise = this.checkAuth();
         promise.then(function (response) {
             customer = response.data;
+
+            // @todo Remove sending the identity once backend tracking (Sapience/Olytics) has been integrated.
+            identity = response.identity;
+
+            EventDispatcher.trigger('CustomerManager.identity.loaded');
         }, function() {
             Debugger.error('Unable to retrieve a customer.');
         });
@@ -165,6 +177,11 @@ function CustomerManager()
 
     this.getCustomer = function() {
         return customer;
+    }
+
+    // @todo Remove sending the identity once backend tracking (Sapience/Olytics) has been integrated.
+    this.getIdentity = function() {
+        return identity;
     }
 
     this.logout = function() {

--- a/src/AppBundle/Resources/library/js/radix.js
+++ b/src/AppBundle/Resources/library/js/radix.js
@@ -29,6 +29,11 @@
         return CustomerManager.getCustomer();
     };
 
+    // @todo Remove sending the identity once backend tracking (Sapience/Olytics) has been integrated.
+    Radix.getIdentity = function() {
+        return CustomerManager.getIdentity();
+    };
+
     Radix.hasCustomer = function() {
         return CustomerManager.isLoggedIn();
     };

--- a/src/AppBundle/Resources/views/sandbox/index.html.twig
+++ b/src/AppBundle/Resources/views/sandbox/index.html.twig
@@ -30,6 +30,14 @@
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.3/js/bootstrap.min.js" integrity="sha384-ux8v3A6CPtOTqOzMKiuo3d/DomGaaClxFYdCu2HPMBEkf6x2xiDyJ7gkXU0MWwaD" crossorigin="anonymous"></script>
     <script src="{{libraries.js.url}}"></script>
     <script>
+        // @todo Remove sending the identity once backend tracking (Sapience/Olytics) has been integrated.
+        Radix.on('CustomerManager.identity.loaded', function() {
+            console.warn(
+                'This is where one could subscribe to an identity id being loaded. ID:',
+                Radix.getIdentity()
+            );
+        });
+
         Radix.init({{ initConfig|json_encode(constant('JSON_PRETTY_PRINT'))|raw }});
     </script>
 {% endblock %}


### PR DESCRIPTION
The backend Radix application will now add the active customer id to the auth response. By nature of the underlying `CustomerManager`, the active customer is defined as a logged-in account (if available), followed by an active/loaded identity.

The React customer manager will now add this identity value to its internals. Outside services can also subscribe to this event via `CustomerManager.identity.loaded`

In short, this is a "hack" to allow for existing `Sapience` tracking behavior, where an identity id is required to be set for internal user attribution. This should be removed once the tracking functionality of Sapience has been merged with Radix and/or another machine tracking strategy (a la local storage) has been implemented.
