### PR TITLE
Remove service and add integrationId to meta

### DIFF
--- a/app/Resources/As3ModlrBundle/embeds/integration-meta-detail.yml
+++ b/app/Resources/As3ModlrBundle/embeds/integration-meta-detail.yml
@@ -1,6 +1,6 @@
 integration-meta-detail:
     attributes:
-        service:
+        integrationId:
             type: string
         identifier:
             type: string

--- a/src/AppBundle/Integration/Execution/QuestionPullExecution.php
+++ b/src/AppBundle/Integration/Execution/QuestionPullExecution.php
@@ -113,7 +113,7 @@ class QuestionPullExecution extends AbstractExecution
         $choice->set('integration', $meta);
         $meta->set('pull', $pull);
 
-        $pull->set('service', $this->getService()->getKey());
+        $pull->set('integrationId', $this->getIntegration()->getId());
         $pull->set('identifier', $externalId);
 
         $choice->save();
@@ -174,8 +174,8 @@ class QuestionPullExecution extends AbstractExecution
             }
 
             $identifier = $pull->get('identifier');
-            if ($this->getService()->getKey() !== $pull->get('service') || empty($identifier)) {
-                // Service mismatch or missing identifier. Remove choice.
+            if ($this->getIntegration()->getId() !== $pull->get('integrationId') || empty($identifier)) {
+                // Integration mismatch or missing identifier. Remove choice.
                 $this->deleteChoice($choice);
                 continue;
             }


### PR DESCRIPTION
Removes the `service` field from the `integration-meta-detail` model and replaces it with the `integrationId` that the external identifier was generated from. This is how it should have been modeled from the beginning, as the service key is not specific enough for proper storage.

The following must be executed on VSP's database once live. All new implementations will already have this covered as a part of their data migration.

```js
// Change pull meta to use the integration id
db.getCollection('integration').find({ "_type" : "integration-question-pull" }).forEach(function(doc) {
    var question = db.getCollection('question').find({ "pull" : doc._id }).toArray()[0];
    db.getCollection('question-choice').find({ "question" : question._id }).forEach(function(choice) {
        db.getCollection('question-choice').update({ "_id" : choice._id }, {
            $set   : { "integration.pull.integrationId": doc._id.valueOf() },
            $unset : { "integration.pull.service" : 1 }
        });
    });
});
```