### PR TITLE
Add alias for first and last name; use for notify emails

### DIFF
--- a/app/Resources/As3ModlrBundle/models/identity.yml
+++ b/app/Resources/As3ModlrBundle/models/identity.yml
@@ -70,6 +70,18 @@ identity:
         extra:
             type: object
             description: 'Any extra, non-defined identity data.'
+        firstName:
+            type: string
+            description: 'An alias for given name.'
+            calculated:
+                class: AppBundle\CalculatedFields
+                method: identityFirstName
+        lastName:
+            type: string
+            description: 'An alias for famil name.'
+            calculated:
+                class: AppBundle\CalculatedFields
+                method: identityLastName
     embeds:
         addresses:
             type: many

--- a/src/AppBundle/CalculatedFields.php
+++ b/src/AppBundle/CalculatedFields.php
@@ -7,6 +7,16 @@ use As3\Modlr\Models\Model;
 
 class CalculatedFields
 {
+    public static function identityFirstName(Model $model)
+    {
+        return $model->get('givenName');
+    }
+
+    public static function identityLastName(Model $model)
+    {
+        return $model->get('familyName');
+    }
+
     public static function identityEmailEmbeddablePrimaryEmail(Model $model)
     {
         $primary = null;

--- a/src/AppBundle/Notifications/NotificationManager.php
+++ b/src/AppBundle/Notifications/NotificationManager.php
@@ -284,7 +284,7 @@ class NotificationManager
 
         // @todo Use a different inflector???
         $inflector = Inflector::get('en');
-        foreach (['givenName', 'familyName', 'companyName', 'title', 'primaryEmail'] as $key) {
+        foreach (['firstName', 'lastName', 'companyName', 'title', 'primaryEmail'] as $key) {
             $values[$inflector->titleize($key)] = $identity->get($key);
         }
         if (null !== $address = $identity->get('primaryAddress')) {


### PR DESCRIPTION
Creates aliased fields `firstName` and `lastName` and ensures that they are used for all default notify emails.

![image](https://cloud.githubusercontent.com/assets/3289485/20075558/4602c3d0-a4fa-11e6-8630-359b0b4e97c1.png)
