### PR TITLE
Ensure mechanism is changed when resetting passwd

### DIFF
--- a/src/AppBundle/Submission/Handlers/AccountResetPasswordHandler.php
+++ b/src/AppBundle/Submission/Handlers/AccountResetPasswordHandler.php
@@ -40,6 +40,7 @@ class AccountResetPasswordHandler implements SubmissionHandlerInterface
         $password->set('mechanism', 'platform');
         $password->set('resetCode', null);
         $password->set('value', $payload->getIdentity()->get('password'));
+        $password->set('salt', null);
 
         $submission->set('identity', $this->accountModel);
     }


### PR DESCRIPTION
Due to password encryption being handled in the postValidate method of AccountCredentialPasswordFactory, merick user passwords were being stored in cleartext when resetting.