### PR TITLE
Addresses now clear data when locale changes

### DIFF
--- a/src/AppBundle/Resources/library/js/components/form-country-postal-code.js
+++ b/src/AppBundle/Resources/library/js/components/form-country-postal-code.js
@@ -1,7 +1,7 @@
 React.createClass({ displayName: 'ComponentFormCountryPostalCode',
 
     componentWillReceiveProps: function(props) {
-        this.setState({ countryCode: props.countryCode});
+        this.setState({ countryCode: props.countryCode, postalCode: props.postalCode });
     },
 
     getDefaultProps: function() {
@@ -16,12 +16,15 @@ React.createClass({ displayName: 'ComponentFormCountryPostalCode',
 
     getInitialState: function() {
         return {
-            countryCode: this.props.countryCode
+            countryCode : this.props.countryCode,
+            postalCode  : this.props.postalCode
         };
     },
 
     handleCountryChange: function(event) {
-        this.setState({ countryCode: event.target.value });
+        var code = event.target.value;
+        this.setState({ countryCode: code, postalCode: null });
+
         if (Utils.isFunction(this.props.onChange)) {
             this.props.onChange(event);
         }
@@ -40,9 +43,9 @@ React.createClass({ displayName: 'ComponentFormCountryPostalCode',
         var code = this.state.countryCode;
         var element;
         if ('USA' === code || 'CAN' === code) {
-            element = React.createElement(Radix.Components.get('FormInputText'), { required: this.props.required, ref: this.props.fieldRef, onChange: this.props.onChange, name: 'identity:primaryAddress.postalCode', wrapperClass: 'postalCode', label: 'Zip/Postal Code', value: this.props.postalCode });
+            element = React.createElement(Radix.Components.get('FormInputText'), { required: this.props.required, ref: this.props.fieldRef, onChange: this.props.onChange, name: 'identity:primaryAddress.postalCode', wrapperClass: 'postalCode', label: 'Zip/Postal Code', value: this.state.postalCode });
         } else {
-            element = React.createElement(Radix.Components.get('FormInputHidden'), { ref: this.props.fieldRef, onChange: this.props.onChange, name: 'identity:primaryAddress.postalCode', value: this.props.postalCode });
+            element = React.createElement(Radix.Components.get('FormInputHidden'), { ref: this.props.fieldRef, onChange: this.props.onChange, name: 'identity:primaryAddress.postalCode', value: this.state.postalCode });
         }
         return element;
     }

--- a/src/AppBundle/Utility/LocaleUtility.php
+++ b/src/AppBundle/Utility/LocaleUtility.php
@@ -10,6 +10,42 @@ namespace AppBundle\Utility;
 class LocaleUtility
 {
     /**
+     * Cleans a value for locality comparison purposes.
+     *
+     * @param   mixed   $value
+     * @return  string
+     */
+    public static function cleanValue($value)
+    {
+        $value = trim(strtolower($value));
+        $value = preg_replace_callback('/[^a-z0-9]/i', function($matches) {
+            return '';
+        }, $value);
+        return $value;
+    }
+
+    /**
+     * Determines if two set of locality/address data match.
+     *
+     * @param   array   $current
+     * @param   array   $new
+     * @return  bool
+     */
+    public static function doLocalitiesMatch(array $current, array $new)
+    {
+        foreach (self::getLocalityFieldKeys() as $key) {
+            if (!isset($new[$key])) {
+                continue;
+            }
+
+            if (array_key_exists($key, $current) && self::cleanValue($current[$key]) !== self::cleanValue($new[$key])) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
      * Gets address data from Google's geo-code API for the provided address data.
      *
      * @param   string|array    $address
@@ -69,6 +105,16 @@ class LocaleUtility
             }
         }
         return $crc;
+    }
+
+    /**
+     * Gets the field keys used for comparing locality data.
+     *
+     * @return  array
+     */
+    public static function getLocalityFieldKeys()
+    {
+        return ['street', 'extra', 'city', 'postalCode', 'regionCode', 'countryCode'];
     }
 
     /**


### PR DESCRIPTION
Ensures that, when an address is updated, the new address data is cleared if the locality has changed.