### PR TITLE
Add support for switching app in sandbox

### DIFF
--- a/src/AppBundle/Resources/views/sandbox/_main.html.twig
+++ b/src/AppBundle/Resources/views/sandbox/_main.html.twig
@@ -12,9 +12,9 @@
         <div class="card">
             <div class="card-header">Configuration</div>
             <div class="card-block">
-                <p class="card-text">Override by setting the keys in the query string, a la <code>?appId={some-app-id}</code></p>
+                <p class="card-text"><strong>{{ app.fullName }}</strong></p>
                 <div class="alert alert-info" role="alert">
-                    <pre><samp>{{ initConfig|json_encode(constant('JSON_PRETTY_PRINT')) }}</samp></pre>
+                    <pre><samp>{{ app.config|json_encode(constant('JSON_PRETTY_PRINT')) }}</samp></pre>
                 </div>
             </div>
         </div>

--- a/src/AppBundle/Resources/views/sandbox/_nav.html.twig
+++ b/src/AppBundle/Resources/views/sandbox/_nav.html.twig
@@ -2,8 +2,28 @@
     <div class="container">
         <button class="navbar-toggler hidden-sm-up" type="button" data-toggle="collapse" data-target="#primary-navigation" aria-controls="primary-navigation" aria-expanded="false" aria-label="Toggle navigation">&#9776;</button>
         <div class="collapse navbar-toggleable-xs" id="primary-navigation">
-            <a class='navbar-brand' href="/">Radix Sandbox</a>
+            <a class='navbar-brand' href="/">Radix</a>
             <ul class="nav navbar-nav">
+                {% if apps|length > 1 %}
+                    <li class="nav-item dropdown">
+                        <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="javascript:void(0)" role="button">
+                            {{ app.name }}
+                        </a>
+
+                        <div class="dropdown-menu dropdown-menu-left">
+                            {% for available in apps %}
+                                {% if app.id != available.id %}
+                                    <a class="dropdown-item" href="?appId={{ available.config.appId }}">{{available.fullName}}</a>
+                                {% endif %}
+                            {% endfor %}
+                        </div>
+                    </li>
+                {% else %}
+                    <li class="nav-item">
+                        <span class="nav-link">{{ app.name }}</span>
+                    </li>
+                {% endif %}
+                <!-- HERE -->
                 {% for item in navigation %}
                     {% set active = item.active ? 'active' : '' %}
                     {% if item.children is empty %}

--- a/src/AppBundle/Resources/views/sandbox/index.html.twig
+++ b/src/AppBundle/Resources/views/sandbox/index.html.twig
@@ -48,6 +48,6 @@
             );
         });
 
-        Radix.init({{ initConfig|json_encode(constant('JSON_PRETTY_PRINT'))|raw }});
+        Radix.init({{ app.config|json_encode(constant('JSON_PRETTY_PRINT'))|raw }});
     </script>
 {% endblock %}


### PR DESCRIPTION
The application can now be switched, depending on the request origin.
Generally speaking, you’ll want to load the sandbox using the domain of the app you’d like to access. Example:
- For `cygnus:vspc`, access the sandbox via `dev.radix.vehicleservicepros.com`
- For `acbm:ooh`, access the sandbox via `dev.radix.oemoffhighway.com`, etc…