### PR TITLE
Fix wrong parameter return order in route info property

### DIFF
--- a/src/AppBundle/Resources/radix/app/components/edit-model.js
+++ b/src/AppBundle/Resources/radix/app/components/edit-model.js
@@ -25,11 +25,11 @@ export default Component.extend({
         return `${this.get('routeName')}.edit`;
     }),
 
-    routeInfo : computed('model', 'routeName', function() {
+    routeInfo : computed('model.id', 'routeName', function() {
         let id = this.get('model.id');
         return [
-            (id) ? [id] : undefined,
             (id) ? this.get('editRouteName') : this.get('routeName'),
+            (id) ? [id] : undefined,
         ];
     }),
 


### PR DESCRIPTION
The computed property should have been returning the route name and then the route params.