### PR TITLE
remove additional logging used for identity stub fix

### DIFF
--- a/app/Resources/As3ModlrBundle/models/identity.yml
+++ b/app/Resources/As3ModlrBundle/models/identity.yml
@@ -82,8 +82,6 @@ identity:
             calculated:
                 class: AppBundle\CalculatedFields
                 method: identityLastName
-        debug:
-            type: object
     embeds:
         addresses:
             type: many

--- a/src/AppBundle/Utility/RequestPayload.php
+++ b/src/AppBundle/Utility/RequestPayload.php
@@ -79,24 +79,6 @@ class RequestPayload
                 $this->{$key}->replace($payload[$key]);
             }
         }
-
-        // @jpdev - temp store some stuff
-        $this->debug['time'] = time();
-        $this->debug['ip'] = $request->getClientIp();
-        $this->debug['referer'] = $request->headers->get('REQUEST_URI  referer');
-        $this->debug['userAgent'] = $request->headers->get('user-agent');
-        $this->debug['origin'] = $request->headers->get('origin');
-        $this->debug['host'] = $request->getHost();
-        $this->debug['path'] = $request->getPathInfo();
-        $this->debug['querystring'] = $request->getQueryString();
-        $this->debug['requestUri'] = $request->getRequestUri();
-        $this->debug['method'] = $request->getMethod();
-        $this->debug['body'] = $request->getContent();
-        foreach ($request->headers AS $key => $value) {
-            $this->debug['headers'][$key] = $value;
-        }
-        $this->identity->set('debug', $this->debug);
-
         return $this;
     }
 


### PR DESCRIPTION
identity stubs not created following fix deployment - removing this logging, and once this is deployed will go in and manually remove the debug data from mongo to complete cleanup.