### PR TITLE
White-space css fix for comments in IE

### DIFF
--- a/src/AppBundle/Resources/library/css/radix.css
+++ b/src/AppBundle/Resources/library/css/radix.css
@@ -287,7 +287,7 @@ ins {
 
     font-size: 15px;
 
-    white-space: pre-line;
+    white-space: normal;
 }
 
 .platform-element .left {


### PR DESCRIPTION
this was fixed for components a while back but never carried over to radix comments

`White-space:normal ` =>
![screen shot 2018-07-23 at 10 09 50 am](https://user-images.githubusercontent.com/12496550/43092704-a1041d60-8e73-11e8-9f15-2481d27fbbe5.png)

`white-space: pre-line` =>
![screen shot 2018-07-23 at 10 10 23 am](https://user-images.githubusercontent.com/12496550/43092709-a2bfad5e-8e73-11e8-891b-ce2344f3c453.png)
