### PR TITLE
Missing token

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ Awesome sauce!!
 
 Developing in Radix
 -------------------------------
-To get started, check out this repository and execute `docker-compose up` in the repository root folder. Your radix instance is now available via http://localhost:8700/manage/ (or whatever port you have configured).
+To get started, check out this repository and execute `docker-compose up` in the repository root folder. Your radix instance is now available via http://dev.radix.as3.io:8700/manage/ (or whatever port you have configured). Due to how cookies are stored for `localhost`, ensure that you add a host entry and use the configured domain name `dev.radix.as3.io`.
+
+If you are testing integration with another application, ensure that your application is added to the Allowed Origins field for the application you are accessing.
 
 To change the `APP` or other run-time environment variables, add the values into a `.env` file at the project root.
 ```sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,6 +66,7 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile
+    image: radix_apache:latest
     ports:
       - "${RADIX_APP_PORT-8700}:80"
     volumes:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,5 @@
 FROM limit0/php56:imagick-latest
+RUN pecl install xdebug-2.5.5 && docker-php-ext-enable xdebug
 
 COPY docker/vhost.conf /etc/apache2/sites-available/000-default.conf
 COPY docker/php.ini /usr/local/etc/php/conf.d/zzz_php.ini

--- a/src/AppBundle/Core/AccountManager.php
+++ b/src/AppBundle/Core/AccountManager.php
@@ -21,7 +21,7 @@ class AccountManager
      * @var array
      */
     private static $globalOrigins = [
-        'http://localhost:*',
+        'http://dev.radix.as3.io:*',
         'http://radix.as3.io',
         'http://*.radix.as3.io',
         'https://radix.as3.io',


### PR DESCRIPTION
Change submission handler for account password reset generator to NOT be an identifiable submission.
- After submitting a reset, due to changes in the `IdentityManager::getActiveIdentity()`, the visitor cookie is used.
- In this case, because it was being treated as an identifiable submission, the identity of the user the password reset was _requested_ for was set as the active identity -- essentially causing them to be logged in.
- Due to the new active identity being returned in the `validateWhenLoggedIn` hook, a user was unable to resend or send a new reset code.
- Because this is no longer an identifiable submission, the restriction of being logged out to send a reset code has been removed.
- Additional dev docker improvements: tagged image name, xdebug, support global origin on hostname & docker port, update docs to indicate preferred access method and `localhost` cookie issue.

**Jira Link**: [CS-71](https://southcomm.atlassian.net/browse/CS-71)