### PR TITLE
Login/Reg form bug fix for iOS11

### DIFF
--- a/server/src/AppBundle/Resources/library/css/radix.css
+++ b/server/src/AppBundle/Resources/library/css/radix.css
@@ -52,6 +52,15 @@ ins {
     -webkit-tap-highlight-color: transparent;
     -webkit-touch-callout: none;
 }
+
+@supports (-webkit-overflow-scrolling: touch) {
+    .platform-element[data-element=modal] {
+        position: absolute;
+        height: 100%;
+    }
+}
+
+
 .platform-element[data-element=modal]#guidrSubmitModal {
     z-index: 3000000;
 


### PR DESCRIPTION
Replicate css that was done for components that fixes a bug for old versions of iOS (11 and earlier, 12 is the newest atm, for reference) When the keyboard pops up as you select an input field, sometimes the cursor doesn't line up properly with the input fields: https://southcomm.atlassian.net/browse/CS-59
