### PR TITLE
Radix app landing page link fix

### DIFF
--- a/admin/app/templates/index.hbs
+++ b/admin/app/templates/index.hbs
@@ -9,7 +9,7 @@
         <div class="list-group-item d-flex justify-content-between align-items-center">
           {{#if user-manager.permissions}}
             <span class="">{{entypo-icon "chat" class="mr-3"}}Moderate Comments</span>
-            {{#link-to "app.comments" session.data.application._id class="btn btn-sm btn-primary"}}go{{/link-to}}
+            {{#link-to "app.comments" this.user-manager.applicationId class="btn btn-sm btn-primary"}}go{{/link-to}}
           {{else}}
             <span class="text-muted">{{entypo-icon "chat" class="mr-3"}}Moderate Comments</span>
             <button type="button" class="btn btn-sm btn-disabled" title="No access -- contact your manager for permission.">go</button>
@@ -19,7 +19,7 @@
         <div class="list-group-item d-flex justify-content-between align-items-center">
           {{#if user-manager.permissions.applications.edit}}
             <span class="">{{entypo-icon "users" class="mr-3"}}Manage Users</span>
-            {{#link-to "app.users" session.data.application._id class="btn btn-sm btn-primary"}}go{{/link-to}}
+            {{#link-to "app.users" this.user-manager.applicationId class="btn btn-sm btn-primary"}}go{{/link-to}}
           {{else}}
             <span class="text-muted">{{entypo-icon "users" class="mr-3"}}Manage Users</span>
             <button type="button" class="btn btn-sm btn-disabled" title="No access -- contact your manager for permission.">go</button>
@@ -29,7 +29,7 @@
         <div class="list-group-item d-flex justify-content-between align-items-center">
           {{#if user-manager.permissions.applications.edit}}
             <span class="">{{entypo-icon "tools" class="mr-3"}}Manage Settings</span>
-            {{#link-to "app.settings" session.data.application._id class="btn btn-sm btn-primary"}}go{{/link-to}}
+            {{#link-to "app.settings" this.user-manager.applicationId class="btn btn-sm btn-primary"}}go{{/link-to}}
           {{else}}
             <span class="text-muted">{{entypo-icon "tools" class="mr-3"}}Manage Settings</span>
             <button type="button" class="btn btn-sm btn-disabled" title="No access -- contact your manager for permission.">go</button>


### PR DESCRIPTION
Application ID variable updated - session.data.application._id returns undefined (But works in the navigation, so I didn’t update it there, just index.hbs)

<img width="1658" alt="Screen Shot 2019-05-08 at 9 05 23 AM" src="https://user-images.githubusercontent.com/12496550/57382142-f9574500-7171-11e9-8ebf-822051e9cb8c.png">
